### PR TITLE
Fix audio support on some devices running IOS

### DIFF
--- a/src/makegif.py
+++ b/src/makegif.py
@@ -128,9 +128,10 @@ def motion_caption(in_vid: str, out_vid: str, caption_img: Image, work_dir: str,
             captioned_vid.resize(height=config.video_height)
         captioned_vid.write_videofile(out_vid, logger=None, threads=4, 
                                       bitrate=config.video_bitrate,
-                                      fps=min(config.video_fps, source_vid.fps))
+                                      fps=min(config.video_fps, source_vid.fps), 
+                                      audio_codec="aac")
     else:
-        captioned_vid.write_videofile(out_vid, logger=None, threads=4)
+        captioned_vid.write_videofile(out_vid, logger=None, threads=4, audio_codec="aac")
     
 
     et = time.time()


### PR DESCRIPTION
mp4 files with an audio track using the mp3 codec have trouble playing any audio on ios devices like iphones, this PR changes the default audio codec for outputted videos to aac which is better supported for audio streams in videos.